### PR TITLE
Adding SASL-PLAINTEXT support for Kafka and all dependencies.

### DIFF
--- a/README.azure.md
+++ b/README.azure.md
@@ -56,7 +56,7 @@ export CLIENT_SECRET=$(jq -r .password $SERVICE_PRINCIPAL_FILE)
 
 The reason for pre-creating the service principal is due to a [known issue](https://github.com/Azure/azure-cli/issues/9585) that prevents the `az aks create` command to do it for you. For more information about service principals, follow [this](https://docs.microsoft.com/en-us/azure/aks/kubernetes-service-principal) link.
 
-> **INFO**: Only when the resource group to use for the AKS cluster is new, you can omit the principal creation.
+> **INFO**: When the resource group to use for the AKS cluster is new, you might omit the creation of the service principal account.
 
 With enough quota:
 

--- a/README.kops.md
+++ b/README.kops.md
@@ -154,6 +154,12 @@ ip-172-20-62-60.us-east-2.compute.internal   node   True
 Your cluster aws.agalue.net is ready
 ```
 
+If you have issues, execute the following and then try again:
+
+```
+kops export kubecfg --admin
+```
+
 Or,
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ docker run -it --name minion \
  opennms/minion:27.0.3 -f
 ```
 
-> **IMPORTANT**: Make sure to use the same version as OpenNMS. The above contemplates using a custom content for the `INSTANCE_ID` (see [minion.yaml](minion.yaml)). Make sure it matches the content of [kustomization.yaml](manifests/kustomization.yaml).
+> **IMPORTANT**: Make sure to use the same version as OpenNMS. The above contemplates using a custom content for the `INSTANCE_ID` (see [minion.properties](minion.properties)). Make sure it matches the content of [kustomization.yaml](manifests/kustomization.yaml).
 
 > **WARNING**: Make sure to use your own Domain and Location, and use the same version tag as the OpenNMS manifests.
 

--- a/README.minikube.md
+++ b/README.minikube.md
@@ -86,3 +86,5 @@ docker run -it --rm --name minion \
  -v $(pwd)/minion.properties:/opt/minion-etc-overlay/custom.system.properties \
  opennms/minion:27.0.3 -f
 ```
+
+> **IMPORTANT**: Make sure to use the same version as OpenNMS. The above contemplates using a custom content for the `INSTANCE_ID` (see [minion.properties](minion.properties)). Make sure it matches the content of [kustomization.yaml](manifests/kustomization.yaml).

--- a/manifests/config/kafka-jaas.conf
+++ b/manifests/config/kafka-jaas.conf
@@ -1,0 +1,6 @@
+KafkaServer {
+  org.apache.kafka.common.security.plain.PlainLoginModule required
+   username="opennms"
+   password="0p3nNM5"
+   user_opennms="0p3nNM5";
+};

--- a/manifests/grpc-server.yaml
+++ b/manifests/grpc-server.yaml
@@ -69,14 +69,44 @@ spec:
             configMapKeyRef:
               key: OPENNMS_INSTANCE_ID
               name: common-settings
+        - name: MAX_MESSAGE_SIZE
+          value: '4194304'
+        # Kafka Consumer
+        - name: CONSUMER_SECURITY_PROTOCOL
+          value: SASL_PLAINTEXT
+        - name: CONSUMER_SASL_MECHANISM
+          value: PLAIN
+        - name: CONSUMER_SASL_USERNAME
+          valueFrom:
+            secretKeyRef:
+              key: KAFKA_SASL_USERNAME
+              name: onms-passwords
+        - name: CONSUMER_SASL_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: KAFKA_SASL_PASSWORD
+              name: onms-passwords
         - name: CONSUMER_AUTO_OFFSET_RESET
           value: latest
         - name: CONSUMER_MAX_PARTITION_FETCH_BYTES
           value: '5000000'
+        # Kafka Producer
+        - name: PRODUCER_SECURITY_PROTOCOL
+          value: SASL_PLAINTEXT
+        - name: PRODUCER_SASL_MECHANISM
+          value: PLAIN
+        - name: PRODUCER_SASL_USERNAME
+          valueFrom:
+            secretKeyRef:
+              key: KAFKA_SASL_USERNAME
+              name: onms-passwords
+        - name: PRODUCER_SASL_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: KAFKA_SASL_PASSWORD
+              name: onms-passwords
         - name: PRODUCER_MESSAGE_MAX_BYTES
           value: '5000000'
-        - name: MAX_MESSAGE_SIZE
-          value: '4194304'
         resources:
           limits:
             cpu: 100m

--- a/manifests/kafka.yaml
+++ b/manifests/kafka.yaml
@@ -84,9 +84,17 @@ spec:
         - name: BROKER_ID_COMMAND
           value: echo ${HOSTNAME##*-}
         - name: KAFKA_LISTENERS
-          value: PLAINTEXT://:9092
-        - name: KAFKA_ADVERTISED_LISTENERS
-          value: PLAINTEXT://:9092
+          value: INSIDE://:9092
+        - name: KAFKA_ADVERTISED_LISTENERS # Kafka available only inside K8s
+          value: INSIDE://:9092
+        - name: KAFKA_LISTENER_SECURITY_PROTOCOL_MAP
+          value: INSIDE:SASL_PLAINTEXT
+        - name: KAFKA_INTER_BROKER_LISTENER_NAME
+          value: INSIDE
+        - name: KAFKA_SASL_MECHANISM_INTER_BROKER_PROTOCOL
+          value: PLAIN
+        - name: KAFKA_SASL_ENABLED_MECHANISMS
+          value: PLAIN
         - name: KAFKA_ZOOKEEPER_CONNECTION_TIMEOUT_MS
           value: '15000'
         - name: KAFKA_ZOOKEEPER_CONNECT
@@ -116,8 +124,15 @@ spec:
           value: producer
         - name: JMX_PORT
           value: '9999'
+        - name: KAFKA_OPTS
+          value: -Djava.security.auth.login.config=/opt/kafka/config/kafka_server_jaas.conf
         - name: KAFKA_JMX_OPTS
-          value: -Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Djava.rmi.server.hostname=$(POD_IP) -Dcom.sun.management.jmxremote.rmi.port=$(JMX_PORT)
+          value: |
+            -Dcom.sun.management.jmxremote
+            -Dcom.sun.management.jmxremote.authenticate=false
+            -Dcom.sun.management.jmxremote.ssl=false
+            -Djava.rmi.server.hostname=$(POD_IP)
+            -Dcom.sun.management.jmxremote.rmi.port=$(JMX_PORT)
         - name: MEM_TOTAL_MB
           valueFrom:
             resourceFieldRef:
@@ -146,6 +161,9 @@ spec:
         volumeMounts:
         - name: data
           mountPath: /kafka
+        - name: config
+          mountPath: /opt/kafka/config/kafka_server_jaas.conf
+          subPath: kafka-jaas.conf
         resources:
           limits:
             memory: 4Gi
@@ -163,6 +181,11 @@ spec:
             port: inside
           initialDelaySeconds: 30
           periodSeconds: 60
+      volumes:
+      - name: config
+        secret:
+          secretName: onms-passwords
+
   volumeClaimTemplates:
   - metadata:
       name: data

--- a/manifests/kustomization.yaml
+++ b/manifests/kustomization.yaml
@@ -57,6 +57,8 @@ configMapGenerator:
 
 secretGenerator:
 - name: onms-passwords
+  files:
+  - config/kafka-jaas.conf
   literals:
   - POSTGRES_PASSWORD=postgres
   - OPENNMS_DB_PASSWORD=opennms
@@ -64,11 +66,15 @@ secretGenerator:
   - GRAFANA_UI_ADMIN_PASSWORD=0p3nNMS
   - GRAFANA_DB_USERNAME=grafana
   - GRAFANA_DB_PASSWORD=grafana
+  - ELASTICSEARCH_USERNAME=elastic
   - ELASTICSEARCH_PASSWORD=elastic
   - KAFKA_MANAGER_APPLICATION_SECRET=0p3nNMS
   - KAFKA_MANAGER_USERNAME=opennms
   - KAFKA_MANAGER_PASSWORD=0p3nNMS
   - HASURA_GRAPHQL_ACCESS_KEY=0p3nNMS
+  # Make sure the following matches config/kafka-jaas.conf
+  - KAFKA_SASL_USERNAME=opennms
+  - KAFKA_SASL_PASSWORD=0p3nNM5
 
 generatorOptions:
   disableNameSuffixHash: true

--- a/manifests/opennms.alec.yaml
+++ b/manifests/opennms.alec.yaml
@@ -45,7 +45,7 @@ spec:
       # Initialize Sentinel Configuration for ALEC in Distributed Mode
       # Requires the same image/version used at runtime: sentinel
       - name: init-config
-        image: opennms/sentinel:27.0.3
+        image: bash
         imagePullPolicy: IfNotPresent
         command: [ bash, /init.sh ]
         env:
@@ -61,6 +61,16 @@ spec:
               name: common-settings
         - name: KAFKA_SERVER
           value: kafka.opennms.svc.cluster.local
+        - name: KAFKA_SASL_USERNAME
+          valueFrom:
+            secretKeyRef:
+              key: KAFKA_SASL_USERNAME
+              name: onms-passwords
+        - name: KAFKA_SASL_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: KAFKA_SASL_PASSWORD
+              name: onms-passwords
         - name: ZOOKEEPER_SERVER
           value: zookeeper.opennms.svc.cluster.local
         volumeMounts:

--- a/manifests/opennms.core.yaml
+++ b/manifests/opennms.core.yaml
@@ -106,6 +106,16 @@ spec:
               name: common-settings
         - name: KAFKA_SERVER
           value: kafka.opennms.svc.cluster.local
+        - name: KAFKA_SASL_USERNAME
+          valueFrom:
+            secretKeyRef:
+              key: KAFKA_SASL_USERNAME
+              name: onms-passwords
+        - name: KAFKA_SASL_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: KAFKA_SASL_PASSWORD
+              name: onms-passwords
         - name: ELASTIC_SERVER
           value: esdata.opennms.svc.cluster.local
         - name: ELASTIC_PASSWORD

--- a/manifests/opennms.minion.yaml
+++ b/manifests/opennms.minion.yaml
@@ -114,6 +114,16 @@ spec:
               name: common-settings
         - name: KAFKA_SERVER
           value: kafka.opennms.svc.cluster.local
+        - name: KAFKA_SASL_USERNAME
+          valueFrom:
+            secretKeyRef:
+              key: KAFKA_SASL_USERNAME
+              name: onms-passwords
+        - name: KAFKA_SASL_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: KAFKA_SASL_PASSWORD
+              name: onms-passwords
         - name: JAEGER_AGENT_HOST # Should be consistent with jaeger.yaml
           value: onms-tracing-agent.opennms.svc.cluster.local
         volumeMounts:
@@ -249,6 +259,20 @@ spec:
           value: '50002' # Must match containerPort for nxos-grpc
         - name: TOPIC
           value: $(INSTANCE_ID).Sink.Telemetry-NXOS
+        - name: KAFKA_SECURITY_PROTOCOL
+          value: SASL_PLAINTEXT
+        - name: KAFKA_SASL_MECHANISM
+          value: PLAIN
+        - name: KAFKA_SASL_USERNAME
+          valueFrom:
+            secretKeyRef:
+              key: KAFKA_SASL_USERNAME
+              name: onms-passwords
+        - name: KAFKA_SASL_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: KAFKA_SASL_PASSWORD
+              name: onms-passwords
         ports:
         - containerPort: 50002
           protocol: TCP

--- a/manifests/opennms.sentinel.yaml
+++ b/manifests/opennms.sentinel.yaml
@@ -69,7 +69,7 @@ spec:
       # Initialize Sentinel Configuration
       # Requires the same image/version used at runtime: sentinel
       - name: init-config
-        image: opennms/sentinel:27.0.3
+        image: bash
         imagePullPolicy: IfNotPresent
         command: [ bash, /init.sh ]
         env:
@@ -85,6 +85,16 @@ spec:
               name: common-settings
         - name: KAFKA_SERVER
           value: kafka.opennms.svc.cluster.local
+        - name: KAFKA_SASL_USERNAME
+          valueFrom:
+            secretKeyRef:
+              key: KAFKA_SASL_USERNAME
+              name: onms-passwords
+        - name: KAFKA_SASL_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: KAFKA_SASL_PASSWORD
+              name: onms-passwords
         - name: CASSANDRA_SERVER
           value: cassandra.opennms.svc.cluster.local
         - name: ELASTIC_SERVER


### PR DESCRIPTION
Even if Kafka is not exposed to the Internet and a gRPC is used for external Minions, it is a good exercise to know how to enable at least plaintext client authentication for the Kafka cluster.